### PR TITLE
add server in default config, now could get an express instance from …

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -56,7 +56,8 @@ var defaultConfig = {
   files: [],
   logger: {},
   plugins: [],
-  port: 8080
+  port: 8080,
+  server: (0, _express2['default'])()
 };
 
 function hypernova(userConfig, onServer) {
@@ -68,7 +69,8 @@ function hypernova(userConfig, onServer) {
 
   _logger2['default'].init(config.logger);
 
-  var app = (0, _express2['default'])();
+  /* could get an express instance from config */
+  var app = config.server;
 
   if (config.devMode) {
     (0, _worker2['default'])(app, config, onServer);

--- a/src/server.js
+++ b/src/server.js
@@ -21,6 +21,7 @@ const defaultConfig = {
   logger: {},
   plugins: [],
   port: 8080,
+  server: express(),
 };
 
 export default function hypernova(userConfig, onServer) {
@@ -32,7 +33,8 @@ export default function hypernova(userConfig, onServer) {
 
   logger.init(config.logger);
 
-  const app = express();
+  /* could get an express instance from config */
+  const app = config.server;
 
   if (config.devMode) {
     worker(app, config, onServer);


### PR DESCRIPTION
get an express instance from local, could working with webpack-dev-server, so that we could only start one express instance at local.